### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - LARAVEL_ECHO_SERVER_HOST=0.0.0.0
       - LARAVEL_ECHO_SERVER_PORT=6001
       - ECHO_REDIS_PORT=6379
-      - ECHO_REDIS_HOST=redis
+      - ECHO_REDIS_HOSTNAME=redis
       - ECHO_PROTOCOL=http
       - ECHO_ALLOW_CORS=true
       - ECHO_ALLOW_ORIGIN=*


### PR DESCRIPTION
Complements on an awesome project.  I was testing this in an environment where I had two redis servers running and noticed that ECHO_REDIS_HOST wasn't accepted in the compose file.  Looks like at some point, this has changed to ECHO_REDIS_HOSTNAME -

For reference, here is the laravel-echo-server.example.json file that is sourced and changed, during startup of the laravel-echo-server container -

```
# cat laravel-echo-server.example.json
{
	"authHost": "http://localhost",
	"authEndpoint": "/broadcasting/auth",
	"clients": {{ ECHO_CLIENTS }},
	"database": "redis",
	"databaseConfig": {
		"redis": {
      "port": "{{ ECHO_REDIS_PORT }}",
      "host": "{{ ECHO_REDIS_HOSTNAME }}"
		}
	},
	"devMode": "{{ ECHO_DEVMODE }}",
	"host": null,
	"port": "6001",
	"protocol": "{{ ECHO_PROTOCOL }}",
	"socketio": {},
	"sslCertPath": "{{ ECHO_SSL_CERT_PATH }}",
	"sslKeyPath": "{{ ECHO_SSL_KEY_PATH }}",
	"sslCertChainPath": "{{ ECHO_SSL_CHAIN_PATH }}",
	"sslPassphrase": "{{ ECHO_SSL_PASSPHRASE }}",
	"apiOriginAllow": {
		"allowCors": {{ ECHO_ALLOW_CORS }},
		"allowOrigin": "{{ ECHO_ALLOW_ORIGIN }}",
		"allowMethods": "{{ ECHO_ALLOW_METHODS }}",
		"allowHeaders": "{{ ECHO_ALLOW_HEADERS }}"
	}
```