### PR TITLE
Fix Redis environment variable name

### DIFF
--- a/kubernetes/laravel-echo-server.deployment.yml
+++ b/kubernetes/laravel-echo-server.deployment.yml
@@ -35,7 +35,7 @@ spec:
             value: '*'
           - name: ECHO_PROTOCOL
             value: http
-          - name: ECHO_REDIS_HOST
+          - name: ECHO_REDIS_HOSTNAME
             value: redis
           - name: ECHO_REDIS_PORT
             value: "6379"


### PR DESCRIPTION
mintopia/laravel-echo-server [expects ](https://github.com/mintopia/laravel-echo-server/blob/master/files/opt/laravel-echo-server/entrypoint.sh) `ECHO_REDIS_HOSTNAME` but not `ECHO_REDIS_HOST` name of Redis host environment veriable, otherwise it will use default `redis`