### PR TITLE
Make WebApp dependency with redis explicit on docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - CACHE_DRIVER=redis
       - QUEUE_DRIVER=redis
       - ECHO_HOST_MODE=path
+    depends_on:
+      - redis
 
   redis:
     image: "redis:alpine"


### PR DESCRIPTION
Sometimes, in some slow VPS, when trying to start with docker compose, the webapp instance loads before the redis which causes a connection error.

i've been only been able to reproduce this in a basic DigitallOcean VPS. It doesn't happen all the time tho.

This PR just add a [depends_on](https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on) to make this loading order explicit

![Screenshot from 2022-11-14 23-12-34](https://user-images.githubusercontent.com/20696570/201780987-ac7f1660-fff1-44cd-8ffc-ff621ef17ed4.png)

![Screenshot from 2022-11-14 23-12-46](https://user-images.githubusercontent.com/20696570/201780984-b877a30f-4199-4f6c-a37b-6ddc68fedffb.png)
