### PR TITLE
Remove obsolete `version` field from docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   webhook:
     image: "webhooksite/webhook.site"


### PR DESCRIPTION
Running `docker compose up` logs a warning:

```
WARN[0000] docker-compose.yml: `version` is obsolete
```