### PR TITLE
added container names to fix broken socket.io connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   webhook:
+    container_name: "webhook-site"
     image: "webhooksite/webhook.site"
     # Enable build for development:
     # build:
@@ -23,9 +24,11 @@ services:
       - redis
 
   redis:
+    container_name: "webhook-redis"
     image: "redis:alpine"
 
   laravel-echo-server:
+    container_name: "laravel-echo-server"
     image: "webhooksite/laravel-echo-server"
     environment:
       - LARAVEL_ECHO_SERVER_AUTH_HOST=http://webhook


### PR DESCRIPTION
This pull request includes changes to the `docker-compose.yml` file, primarily adding container names to fix broken socket.io connections as reported in #165 

Changes to `docker-compose.yml`:

* Added `container_name` for the `webhook` service (`webhook-site`). (`[docker-compose.ymlR3](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R3)`)
* Added `container_name` for the `redis` service (`webhook-redis`). (`[docker-compose.ymlR27-R31](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R27-R31)`)
* Added `container_name` for the `laravel-echo-server` service (`laravel-echo-server`). (`[docker-compose.ymlR27-R31](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R27-R31)`)